### PR TITLE
Added cast to qreal, avoiding ftbfs due to issue #758

### DIFF
--- a/QTfrontend/drawmapscene.cpp
+++ b/QTfrontend/drawmapscene.cpp
@@ -459,7 +459,7 @@ QList<QPointF> DrawMapScene::makeEllipse(const QPointF &center, const QPointF &c
         l.append(center);
     } else
     {
-        qreal angleDelta = qMax(0.1, qMin(0.7, 120 / r));
+        qreal angleDelta = qMax(static_cast<qreal> (0.1), qMin(static_cast<qreal> (0.7), 120 / r));
         for(qreal angle = 0.0; angle < 2*M_PI; angle += angleDelta)
             l.append(center + QPointF(rx * cos(angle), ry * sin(angle)));
         l.append(l.first());


### PR DESCRIPTION
More explanation here
https://wiki.debian.org/ArmEabiFixes
And on qt-project.org reference website:
"Typedef for double on all platforms except for those using CPUs with ARM architectures. On ARM-based platforms, qreal is a typedef for float for performance reasons."
