### PR TITLE
Do not throw error when an haskell module throws a build failure, e.g. b...

### DIFF
--- a/cmake_modules/CheckHaskellModuleExists.cmake
+++ b/cmake_modules/CheckHaskellModuleExists.cmake
@@ -30,11 +30,11 @@ macro(CHECK_HASKELL_MODULE_EXISTS MODULE FUNCTION PARAMCOUNT LIBRARY)
                     "-DPARAMETERS=${PARAMETERS}"
                     -cpp
                     -c "${CMAKE_MODULE_PATH}/checkModule.hs"
+                    RESULT_VARIABLE COMMAND_RESULT
                     ERROR_VARIABLE BUILD_ERROR
                     OUTPUT_STRIP_TRAILING_WHITESPACE
                     )
-
-    if("${BUILD_ERROR}" STREQUAL "")
+    if(${COMMAND_RESULT} EQUAL 0)
       message(STATUS "Looking for ${FUNCTION} in ${MODULE} - found")
       set(${VARIABLE} 1 CACHE INTERNAL "Have module ${MODULE}")
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log


### PR DESCRIPTION
...ecause of false positives like this one (debian/arm*)

"You are using a new version of LLVM that hasn't been tested yet!
We will try though..."