### PR TITLE
Find lua 5.1 on fedora machines (taken from fedora hw git)

### DIFF
--- a/cmake_modules/FindLua.cmake
+++ b/cmake_modules/FindLua.cmake
@@ -17,7 +17,7 @@ include(FindPackageHandleStandardArgs)
 
 find_path(LUA_INCLUDE_DIR lua.h
                           PATHS /usr/include /usr/local/include /usr/pkg/include
-                          PATH_SUFFIXES lua5.1 lua51)
+                          PATH_SUFFIXES lua5.1 lua51 lua-5.1)
 find_library(LUA_LIBRARY NAMES lua51 lua5.1 lua-5.1 lua
                          PATHS /lib /usr/lib /usr/local/lib /usr/pkg/lib)
 


### PR DESCRIPTION
http://pkgs.fedoraproject.org/cgit/hedgewars.git/tree/hedgewars-lua-search.patch?id=9fdf38a991472de1796d1dafdaea7bc980af48c0