### PR TITLE
Limited sndPoisonMoan playbacks to 1 per team

### DIFF
--- a/hedgewars/uGears.pas
+++ b/hedgewars/uGears.pas
@@ -117,8 +117,10 @@ var Gear: PGear;
     i: LongWord;
     flag: Boolean;
     tmp: LongWord;
+    poisonPlayed: Boolean;
 begin
     Gear:= GearsList;
+    poisonPlayed:= false;
 
     while Gear <> nil do
     begin
@@ -155,7 +157,11 @@ begin
             if tmp > 0 then
                 begin
                 inc(Gear^.Damage, min(tmp, max(0,Gear^.Health - 1 - Gear^.Damage)));
-                HHHurt(Gear^.Hedgehog, dsPoison);
+                if not poisonPlayed then
+                    begin
+                    HHHurt(Gear^.Hedgehog, dsPoison);
+                    poisonPlayed:= true;
+                    end
                 end
             end;
 


### PR DESCRIPTION
This fixed the issue described in an old forum post
http://www.hedgewars.org/node/2776

In few words: sndPoisonMoan is played for every hedge on map. If number of hedges is high, this leads to significant boost of sndPoisonMoan (as all sounds are mixed additively)