### PR TITLE
Enable all lints from rust-2018-idioms as warnings

### DIFF
--- a/gameServer2/src/main.rs
+++ b/gameServer2/src/main.rs
@@ -1,4 +1,6 @@
 #![allow(unused_imports)]
+#![deny(bare_trait_objects)]
+#![warn(unreachable_pub)]
 
 extern crate rand;
 extern crate mio;

--- a/gameServer2/src/protocol/test.rs
+++ b/gameServer2/src/protocol/test.rs
@@ -65,7 +65,7 @@ impl Arbitrary for Ascii {
     }
 
     type Strategy = BoxedStrategy<Ascii>;
-    type ValueTree = Box<ValueTree<Value = Ascii>>;
+    type ValueTree = Box<dyn ValueTree<Value = Ascii>>;
 }
 
 pub fn gen_proto_msg() -> BoxedStrategy<HWProtocolMessage> where {


### PR DESCRIPTION
Rationale: `gameServer2` is still at a very early stage of development and has a lot of unused warnings anyway. These warnings will allow us to move to the Rust 2018 idioms more easily.