### PR TITLE
Fix build with Qt 5.15+

### DIFF
--- a/QTfrontend/ui/page/pagegamestats.cpp
+++ b/QTfrontend/ui/page/pagegamestats.cpp
@@ -21,6 +21,7 @@
 #include <QHBoxLayout>
 #include <QGraphicsScene>
 #include <QGroupBox>
+#include <QPainterPath>
 #include <QSizePolicy>
 
 #include "pagegamestats.h"


### PR DESCRIPTION
```
/build/hedgewars/src/hedgewars-src-1.0.0/QTfrontend/ui/page/pagegamestats.cpp: In member function ‘void PageGameStats::renderStats()’:
/build/hedgewars/src/hedgewars-src-1.0.0/QTfrontend/ui/page/pagegamestats.cpp:222:26: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  222 |             QPainterPath path;
      |                          ^~~~
```