### PR TITLE
Space-filling graph at the end of the game

### DIFF
--- a/QTfrontend/ui/page/pagegamestats.cpp
+++ b/QTfrontend/ui/page/pagegamestats.cpp
@@ -251,10 +251,11 @@ void PageGameStats::renderStats()
             path.lineTo(0, 1);
 
             // Draw clan health/score graph lines
-            QColor col = QColor(c);
+            QColor darkCol = col.darker(125);
 
-            QBrush brush(col);
-            m_scene->addPath(path, Qt::NoPen, brush);
+            QBrush brush(darkCol);
+            QPen pen = Qt::NoPen;
+            m_scene->addPath(path, pen, brush);
 
             ++i;
         }
@@ -262,7 +263,7 @@ void PageGameStats::renderStats()
 
         graphic->setScene(m_scene.data());
 
-        graphic->setSceneRect(0, 0, max(maxDataPoints-1, 1), 1);
+        graphic->setSceneRect(0, 0, std::max(1, maxDataPoints-1), 1);
 
         graphic->fitInView(graphic->sceneRect());
 
@@ -281,7 +282,7 @@ void PageGameStats::applySpacing()
     }
     if ((!gbDetails->isHidden()) && (!gbRanks->isHidden()))
     {
-        pageLayout->setColumnStretch(0, 1);
+        pageLayout->setColumnStretch(0, 0);
         pageLayout->setColumnStretch(1, 1);
         pageLayout->setHorizontalSpacing(20);
     }

--- a/QTfrontend/ui/page/pagegamestats.cpp
+++ b/QTfrontend/ui/page/pagegamestats.cpp
@@ -23,7 +23,6 @@
 #include <QGroupBox>
 #include <QSizePolicy>
 #include <QPainterPath>
-//#include <stl_algo>
 
 #include "pagegamestats.h"
 #include "team.h"
@@ -263,7 +262,7 @@ void PageGameStats::renderStats()
 
         graphic->setScene(m_scene.data());
 
-        graphic->setSceneRect(0, 0, max(maxDataPoints-1. 1), 1);
+        graphic->setSceneRect(0, 0, max(maxDataPoints-1, 1), 1);
 
         graphic->fitInView(graphic->sceneRect());
 


### PR DESCRIPTION
![Screenshot_2021-03-04_20-40-34](https://user-images.githubusercontent.com/12109031/110022906-cad63100-7d2c-11eb-92ac-9a854931e96c.png)

I feel like the end of game graph would look better if it was space filling. Otherwise it is so hard to see what is really going on at the end of the game when there is very little health going around (like in sudden death). I have implemented a Age-of-Empires style health screen, which I feel gives a better overview.

Please let me know if anything needs to be improved.