### PR TITLE
Change the IRC link to Libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ for a more complete list of authors.
 Contact
 -------
 * Homepage        - https://hedgewars.org/
-* IRC channel     - irc://irc.freenode.net/hedgewars
+* IRC channel     - https://web.libera.chat/#hedgewars
 * Community forum - https://hedgewars.org/forum
 


### PR DESCRIPTION
The old link in `README` points to Freenode.

Libera also offers a Kiwi IRC webchat, which I see as more convenient to an average user, who just wants to access the chat and is not accustomed to IRC. Therefore I replaced it with a link to the webchat instance.
