### PR TITLE
fix build of pas2c with ghc-9.4

### DIFF
--- a/tools/pas2c/PascalBasics.hs
+++ b/tools/pas2c/PascalBasics.hs
@@ -2,7 +2,7 @@
 module PascalBasics where
 
 import Text.Parsec.Combinator
-import Text.Parsec.Char
+import Text.Parsec.Char hiding (string')
 import Text.Parsec.Prim
 import Text.Parsec.Token
 import Text.Parsec.Language

--- a/tools/pas2c/PascalParser.hs
+++ b/tools/pas2c/PascalParser.hs
@@ -4,7 +4,7 @@ module PascalParser (
     )
     where
 
-import Text.Parsec
+import Text.Parsec hiding (string')
 import Text.Parsec.Token
 import Text.Parsec.Expr
 import Control.Monad
@@ -720,4 +720,3 @@ redoUnit = do
     string' "var"
     v <- varsDecl True
     return $ Redo (t ++ v)
-

--- a/tools/pas2c/PascalPreprocessor.hs
+++ b/tools/pas2c/PascalPreprocessor.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module PascalPreprocessor where
 
-import Text.Parsec
+import Text.Parsec hiding (string')
 import Control.Monad.IO.Class
 import Control.Monad
 import System.IO


### PR DESCRIPTION
fixes this build failure:
```
hedgewars-src-1.0.2/tools/pas2c/PascalBasics.hs:46:11: error:
    Ambiguous occurrence string'
    It could refer to
       either Text.Parsec.Char.string',
              imported from `Text.Parsec.Char' at /var/home/petersen/fedora/haskell/hedgewars/BUILD/hedgewars-src-1.0.2/tools/pas2c/PascalBasics.hs:5:1-23
           or PascalBasics.string',
              defined at /var/home/petersen/fedora/haskell/hedgewars/BUILD/hedgewars-src-1.0.2/tools/pas2c/PascalBasics.hs:17:1
   |
46 |     try $ string' "{$"
   |           ^^^^^^^
```