### PR TITLE
Fix type error

### DIFF
--- a/hedgewars/SDLh.pas
+++ b/hedgewars/SDLh.pas
@@ -886,7 +886,7 @@ type
 
     PSDL_Event = ^TSDL_Event;
     TSDL_Event = record
-        case LongInt of
+        case LongWord of
             SDL_FIRSTEVENT: (type_: LongWord);
             SDL_COMMONDEVENT: (common: TSDL_CommonEvent);
             SDL_WINDOWEVENT: (window: TSDL_WindowEvent);


### PR DESCRIPTION
There is a type mismatch here https://github.com/hedgewars/hw/blob/9bb78c07da1541ae15440c0f65877f242289206f/hedgewars/SDLh.pas#L889 According to the SDL2 documentation https://wiki.libsdl.org/SDL2/SDL_Event, a 32-bit unsigned number is required here, but `LongInt` is a signed 32-bit number.
